### PR TITLE
Fix: Correct SSH key and app.py paths for CI/CD pipeline

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -23,16 +23,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Create directory for keys
-        run: mkdir -p ~/.ssh
-
       - name: Create public key file
-        run: echo "${{ secrets.PUBLIC_SSH_KEY }}" > ~/.ssh/terraform_key.pub
+        run: echo "${{ secrets.PUBLIC_SSH_KEY }}" > ./main/terraform_key.pub
 
       - name: Create private key file
         run: |
-          echo "${{ secrets.PRIVATE_SSH_KEY }}" > ~/.ssh/terraform_key
-          chmod 600 ~/.ssh/terraform_key 
+          echo "${{ secrets.PRIVATE_SSH_KEY }}" > ./main/terraform_key
+          chmod 600 ./main/terraform_key
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3

--- a/modules/ec2_instance/main.tf
+++ b/modules/ec2_instance/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 resource "aws_key_pair" "example" {
     key_name   = "terraform demo pubudu"
-   public_key = file("~/.ssh/terraform_key.pub") # Updated path
+   public_key = file("../main/terraform_key.pub") # Updated path
 }
 
 
@@ -85,12 +85,12 @@ resource "aws_instance" "example" {
    connection {
         type = "ssh"
         user = "ubuntu"
-        private_key = file("~/.ssh/terraform_key")
+        private_key = file("../main/terraform_key")
         host = self.public_ip
     }
 
     provisioner "file" {
-    source      = "app.py"  
+    source      = "../main/app.py"
     destination = "/home/ubuntu/app.py"  
   }
 


### PR DESCRIPTION
- Modified Terraform configuration in modules/ec2_instance/main.tf to use relative paths for SSH public and private keys, pointing to the main/ directory.
- Updated the file provisioner source for app.py to correctly reference its location in the main/ directory.
- Adjusted the GitHub Actions workflow to create SSH key files directly in the main/ directory, aligning with the Terraform configuration changes.